### PR TITLE
DOC: Update bibtex citation from arXiv to NeurIPS2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,20 @@ Every record has **both image and DNA** data.
 If you make use of the BIOSCAN-5M dataset and/or this code repository, please cite the following [paper](https://arxiv.org/abs/2406.12723):
 
 ```bibtex
-@misc{gharaee2024bioscan5m,
+@inproceedings{gharaee2024bioscan5m,
     title={{BIOSCAN-5M}: A Multimodal Dataset for Insect Biodiversity},
+    booktitle={Advances in Neural Information Processing Systems},
     author={Zahra Gharaee and Scott C. Lowe and ZeMing Gong and Pablo Millan Arias
         and Nicholas Pellegrino and Austin T. Wang and Joakim Bruslund Haurum
         and Iuliia Zarubiieva and Lila Kari and Dirk Steinke and Graham W. Taylor
         and Paul Fieguth and Angel X. Chang
     },
+    editor={A. Globerson and L. Mackey and D. Belgrave and A. Fan and U. Paquet and J. Tomczak and C. Zhang},
+    pages={36285--36313},
+    publisher={Curran Associates, Inc.},
     year={2024},
-    eprint={2406.12723},
-    archivePrefix={arXiv},
-    primaryClass={cs.LG},
-    doi={10.48550/arxiv.2406.12723},
+    volume={37},
+    url={https://proceedings.neurips.cc/paper_files/paper/2024/file/3fdbb472813041c9ecef04c20c2b1e5a-Paper-Datasets_and_Benchmarks_Track.pdf},
 }
 ```
 


### PR DESCRIPTION
The NeurIPS proceedings are out now, so I think we should change our recommended bibtex from arXiv to the NeurIPS version.