### PR TITLE
Setup issue template for reporting record issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/report.md
+++ b/.github/ISSUE_TEMPLATE/report.md
@@ -1,27 +1,29 @@
 ---
 name: Report a record issue
-about: Report a problem or suggest updates to BIOSCAN-5M
-title: "[Record ID]: "
+about: From this template you can report a problem or suggest updates to BIOSCAN-5M.
+title: "[Record ID]: [Report type]"
 labels: report
 ---
+
+> From this template you can report a problem or suggest updates to BIOSCAN-5M. Alternatively, you can submit a report from [BIOSCAN Browser](https://bioscan-browser.netlify.app/report), using an interactive form.
+>
+> After submitting, you can follow the report progress in our [GitHub project](https://github.com/orgs/bioscan-ml/projects/2). If the report is approved, the update will be included with the next version of the dataset. Thank you for helping us improve BIOSCAN-5M!
 
 ## Record details
 
 ### Record ID
 
-Please include the record ID. Both here and as part of the issue title.
+Please include the record ID (`processid`). Both here and as part of the issue title.
 
 ### Images
 
-Paste any images here.
-
-### Metadata
-
-Include any metadata here.
+If the report is related to record images, pasting images here is helpful, but optional.
 
 ## Report details
 
 ### Report type
+
+Please specify what type of issue is being reported by checking one of the items.
 
 - [ ] No insect in the image
 - [ ] Insect is not clearly visible
@@ -30,7 +32,7 @@ Include any metadata here.
 - [ ] Metadata is not correct
 - [ ] Contest current label
 - [ ] Suggest label for deeper taxonomic level
-- [ ] Other report
+- [x] Other report
 
 ### Comments
 

--- a/.github/ISSUE_TEMPLATE/report.md
+++ b/.github/ISSUE_TEMPLATE/report.md
@@ -1,0 +1,37 @@
+---
+name: Report a record issue
+about: Report a problem or suggest updates to BIOSCAN-5M
+title: "[Record ID]: "
+labels: report
+---
+
+## Record details
+
+### Record ID
+
+Please include the record ID. Both here and as part of the issue title.
+
+### Images
+
+Paste any images here.
+
+### Metadata
+
+Include any metadata here.
+
+## Report details
+
+### Report type
+
+- [ ] No insect in the image
+- [ ] Insect is not clearly visible
+- [ ] Image contains multiple insects
+- [ ] Insect is cropped incorrectly
+- [ ] Metadata is not correct
+- [ ] Contest current label
+- [ ] Suggest label for deeper taxonomic level
+- [ ] Other report
+
+### Comments
+
+Include any comments here. What seems wrong? What would be correct? Why do you think this would be correct?

--- a/.github/ISSUE_TEMPLATE/report.md
+++ b/.github/ISSUE_TEMPLATE/report.md
@@ -13,7 +13,9 @@ labels: report
 
 ### Record ID
 
-Please include the record ID (`processid`). Both here and as part of the issue title.
+Please include the record ID (`processid`), both here and as part of the issue title.
+
+Record ID:
 
 ### Images
 

--- a/.github/ISSUE_TEMPLATE/report.md
+++ b/.github/ISSUE_TEMPLATE/report.md
@@ -1,6 +1,6 @@
 ---
 name: Report a record issue
-about: From this template you can report a problem or suggest updates to BIOSCAN-5M.
+about: Report a problem or suggest updates to BIOSCAN-5M from template
 title: "[Record ID]: [Report type]"
 labels: report
 ---


### PR DESCRIPTION
## Summary
Suggesting we setup an issue template in this repo that is matching the form that we will soon include for BIOSCAN Browser.

## Screenshots
Upcoming browser form:
<img width="1728" alt="Screenshot 2025-06-24 at 10 36 00" src="https://github.com/user-attachments/assets/9f851f09-333f-4dc4-9819-ea36389b63d1" />

Issue template preview:
<img width="1728" alt="Screenshot 2025-07-06 at 21 15 28" src="https://github.com/user-attachments/assets/74e24ba6-e6d7-402c-91d6-14e54e654af1" />
<img width="1728" alt="Screenshot 2025-07-06 at 21 15 45" src="https://github.com/user-attachments/assets/a938dd28-88a3-4a9c-b527-d00627338fa7" />