### PR TITLE
MNT: Add broken insect option to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/report.md
+++ b/.github/ISSUE_TEMPLATE/report.md
@@ -29,6 +29,7 @@ Please specify what type of issue is being reported by checking one of the items
 
 - [ ] No insect in the image
 - [ ] Insect is not clearly visible
+- [ ] Image contains a broken insect
 - [ ] Image contains multiple insects
 - [ ] Insect is cropped incorrectly
 - [ ] Metadata is not correct


### PR DESCRIPTION
We have some examples where this option would be helpful (for example https://github.com/bioscan-ml/BIOSCAN-5M/issues/19).

I have already added this option to the browser form.